### PR TITLE
chore: upgrade K8s 1.32 to 1.33

### DIFF
--- a/.github/archive/20260115/workflows/aperag-test-k8s.yml
+++ b/.github/archive/20260115/workflows/aperag-test-k8s.yml
@@ -19,10 +19,10 @@ on:
         required: false
         default: 'gke'
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         type: string
@@ -68,9 +68,9 @@ on:
         required: false
         default: 'gke'
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         required: false

--- a/.github/archive/20260115/workflows/fault-test-k8s.yml
+++ b/.github/archive/20260115/workflows/fault-test-k8s.yml
@@ -19,10 +19,10 @@ on:
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         type: string
@@ -64,9 +64,9 @@ on:
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         required: false

--- a/.github/archive/20260115/workflows/kb-addon-example-schedul-09.yml
+++ b/.github/archive/20260115/workflows/kb-addon-example-schedul-09.yml
@@ -16,7 +16,7 @@ jobs:
       REGION: "${{ vars.REGION_AZURE_AKS }}"
       KB_VERSION: "${{ vars.KUBEBLOCKS_VERSION_09 }}"
       TEST_TYPE: "${{ vars.KUBEBLOCKS_TEST_TYPE_09 }}"
-      CLUSTER_VERSION: "1.32"
+      CLUSTER_VERSION: "1.33"
       INSTANCE_TYPE: "amd64"
       BRANCH_NAME: "main"
       ARGS: " --only-kubectl true --namespace default "

--- a/.github/archive/20260115/workflows/kb-addon-example-schedule.yml
+++ b/.github/archive/20260115/workflows/kb-addon-example-schedule.yml
@@ -16,7 +16,7 @@ jobs:
       REGION: "${{ vars.REGION_AZURE_AKS }}"
       KB_VERSION: "${{ vars.KUBEBLOCKS_VERSION }}"
       TEST_TYPE: "${{ vars.KUBEBLOCKS_TEST_TYPE }}"
-      CLUSTER_VERSION: "1.32"
+      CLUSTER_VERSION: "1.33"
       INSTANCE_TYPE: "amd64"
       BRANCH_NAME: "main"
       ARGS: " --only-kubectl true --namespace demo "

--- a/.github/archive/20260115/workflows/kbcli-test-k3s.yml
+++ b/.github/archive/20260115/workflows/kbcli-test-k3s.yml
@@ -22,9 +22,9 @@ on:
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         required: false
-        default: '1.32'
+        default: '1.33'
       BRANCH_NAME:
         description: 'testinfra branch name'
         required: false
@@ -54,7 +54,7 @@ on:
         description: 'k3s cluster version'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       BRANCH_NAME:
         description: 'testinfra branch name'
         type: string

--- a/.github/archive/20260115/workflows/performance-test-k8s.yml
+++ b/.github/archive/20260115/workflows/performance-test-k8s.yml
@@ -44,10 +44,10 @@ on:
         required: false
         default: 'eks'
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         type: string
@@ -104,9 +104,9 @@ on:
         required: false
         default: 'eks'
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         required: false

--- a/.github/archive/20260115/workflows/test-kbcli-k3s.yml
+++ b/.github/archive/20260115/workflows/test-kbcli-k3s.yml
@@ -34,10 +34,10 @@ on:
         required: false
         default: ''
       k3s-version:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       cloud-provider:
         description: 'cloud k8s cluster provider (e.g. vke/eks/gke/aks)'
         type: string

--- a/.github/archive/workflows/cloud-e2e-k3s-test.yml
+++ b/.github/archive/workflows/cloud-e2e-k3s-test.yml
@@ -19,10 +19,10 @@ on:
         required: false
         default: 'v0.29.0-alpha.167'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string

--- a/.github/archive/workflows/cloud-e2e-with-k3s.yml
+++ b/.github/archive/workflows/cloud-e2e-with-k3s.yml
@@ -24,10 +24,10 @@ on:
         required: false
         default: 'main'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string
@@ -66,10 +66,10 @@ on:
         required: false
         default: 'main'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string

--- a/.github/archive/workflows/cloud-e2e.yml
+++ b/.github/archive/workflows/cloud-e2e.yml
@@ -24,10 +24,10 @@ on:
         required: false
         default: 'main'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string
@@ -76,10 +76,10 @@ on:
         required: false
         default: 'main'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string

--- a/.github/archive/workflows/cloud-test-k3s-free.yml
+++ b/.github/archive/workflows/cloud-test-k3s-free.yml
@@ -14,10 +14,10 @@ on:
         required: false
         default: 'latest'
       K3S_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       E2ETEST_BRANCH:
         description: 'e2etest branch name'
         type: string
@@ -51,10 +51,10 @@ on:
         required: false
         default: 'latest'
       K3S_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       E2ETEST_BRANCH:
         description: 'e2etest branch name'
         type: string

--- a/.github/archive/workflows/cloud-test-k3s.yml
+++ b/.github/archive/workflows/cloud-test-k3s.yml
@@ -14,10 +14,10 @@ on:
         required: false
         default: 'latest'
       K3S_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECLOUD_BRANCH:
         description: 'apecloud branch name'
         type: string
@@ -56,10 +56,10 @@ on:
         required: false
         default: 'latest'
       K3S_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECLOUD_BRANCH:
         description: 'apecloud branch name'
         type: string

--- a/.github/archive/workflows/kbcli-test-k8s.yml
+++ b/.github/archive/workflows/kbcli-test-k8s.yml
@@ -22,9 +22,9 @@ on:
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         required: false
@@ -71,7 +71,7 @@ on:
         description: 'k8s cluster version'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         type: string

--- a/.github/archive/workflows/smoke-test-k8s.yml
+++ b/.github/archive/workflows/smoke-test-k8s.yml
@@ -24,10 +24,10 @@ on:
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         type: string
@@ -74,9 +74,9 @@ on:
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         required: false

--- a/.github/archive/workflows/test-cloud-api-k3d-self.yml
+++ b/.github/archive/workflows/test-cloud-api-k3d-self.yml
@@ -19,10 +19,10 @@ on:
         required: false
         default: 'v0.29.0-alpha.167'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string
@@ -46,10 +46,10 @@ on:
         required: false
         default: 'v0.29.0-alpha.167'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string

--- a/.github/archive/workflows/test-cloud-k3d-self.yml
+++ b/.github/archive/workflows/test-cloud-k3d-self.yml
@@ -9,10 +9,10 @@ on:
         required: false
         default: 'v0.29.0-alpha.163'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string
@@ -26,10 +26,10 @@ on:
         required: false
         default: 'v0.29.0-alpha.163'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string

--- a/.github/archive/workflows/test-cloud-k3d.yml
+++ b/.github/archive/workflows/test-cloud-k3d.yml
@@ -9,10 +9,10 @@ on:
         required: false
         default: 'v0.29.0-alpha.163'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string
@@ -26,10 +26,10 @@ on:
         required: false
         default: 'v0.29.0-alpha.163'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string

--- a/.github/archive/workflows/test-cloud-k3s-free.yml
+++ b/.github/archive/workflows/test-cloud-k3s-free.yml
@@ -29,10 +29,10 @@ on:
         required: false
         default: ''
       k3s-version:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       testinfra-branch:
         description: 'testinfra branch name'
         type: string

--- a/.github/archive/workflows/test-cloud-k3s.yml
+++ b/.github/archive/workflows/test-cloud-k3s.yml
@@ -29,10 +29,10 @@ on:
         required: false
         default: ''
       k3s-version:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       testinfra-branch:
         description: 'testinfra branch name'
         type: string

--- a/.github/archive/workflows/test-cloud-upgrade-k3d-self.yml
+++ b/.github/archive/workflows/test-cloud-upgrade-k3d-self.yml
@@ -14,10 +14,10 @@ on:
         required: false
         default: ''
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string
@@ -36,10 +36,10 @@ on:
         required: false
         default: ''
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string

--- a/.github/archive/workflows/test-cloud-upgrade-k3d.yml
+++ b/.github/archive/workflows/test-cloud-upgrade-k3d.yml
@@ -14,10 +14,10 @@ on:
         required: false
         default: ''
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string
@@ -36,10 +36,10 @@ on:
         required: false
         default: ''
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       APECD_REF:
         description: "The branch name of apecloud-cd"
         type: string

--- a/.github/workflows/cloud-e2e-installer.yml
+++ b/.github/workflows/cloud-e2e-installer.yml
@@ -9,10 +9,10 @@ on:
         required: false
         default: 'main'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       CURRENT_VERSION:
         description: "The current release version (e.g. v0.30) "
         type: string
@@ -31,10 +31,10 @@ on:
         required: false
         default: 'main'
       K3S_VERSION:
-        description: 'k3s cluster version (e.g. 1.32)'
+        description: 'k3s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       CURRENT_VERSION:
         description: "The current release version (e.g. v0.30) "
         type: string
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s-version: [ v1.22, v1.32 ]
+        k3s-version: [ v1.22, v1.33 ]
     steps:
       - name: Free disk space
         continue-on-error: true
@@ -207,7 +207,7 @@ jobs:
                   v1.22)
                       echo installer-result-1-22="${installer_result}" >> $GITHUB_OUTPUT
                   ;;
-                  v1.32)
+                  v1.33)
                       echo installer-result-1-32="${installer_result}" >> $GITHUB_OUTPUT
                   ;;
               esac
@@ -235,7 +235,7 @@ jobs:
                   v1.22)
                       echo installer-result-1-22="${installer_result}" >> $GITHUB_OUTPUT
                   ;;
-                  v1.32)
+                  v1.33)
                       echo installer-result-1-32="${installer_result}" >> $GITHUB_OUTPUT
                   ;;
               esac
@@ -329,7 +329,7 @@ jobs:
                   v1.22)
                       echo bootstrapper-result-1-22="${bootstrapper_result}" >> $GITHUB_OUTPUT
                   ;;
-                  v1.32)
+                  v1.33)
                       echo bootstrapper-result-1-32="${bootstrapper_result}" >> $GITHUB_OUTPUT
                   ;;
               esac
@@ -375,7 +375,7 @@ jobs:
                   v1.22)
                       echo bootstrapper-result-1-22="${bootstrapper_result}" >> $GITHUB_OUTPUT
                   ;;
-                  v1.32)
+                  v1.33)
                       echo bootstrapper-result-1-32="${bootstrapper_result}" >> $GITHUB_OUTPUT
                   ;;
               esac
@@ -684,10 +684,10 @@ jobs:
           if [[ "${{ inputs.CURRENT_VERSION }}" != 'v0.28' && "${{ inputs.CURRENT_VERSION }}" != '0.28' ]]; then
               TEST_RESULT="${TEST_RESULT}##installer-test-v1.22|v1.22|bootstrapper-${CLOUD_BRANCH}|${BOOTSTRAPPER_RESULT_1_21}"
           
-              TEST_RESULT="${TEST_RESULT}##installer-test-v1.32|v1.32|installer-${CLOUD_BRANCH}|${INSTALLER_RESULT_1_32}"
-              TEST_RESULT="${TEST_RESULT}##installer-test-v1.32|v1.32|bootstrapper-${CLOUD_BRANCH}|${BOOTSTRAPPER_RESULT_1_32}"
+              TEST_RESULT="${TEST_RESULT}##installer-test-v1.33|v1.33|installer-${CLOUD_BRANCH}|${INSTALLER_RESULT_1_32}"
+              TEST_RESULT="${TEST_RESULT}##installer-test-v1.33|v1.33|bootstrapper-${CLOUD_BRANCH}|${BOOTSTRAPPER_RESULT_1_32}"
           else
-              TEST_RESULT="${TEST_RESULT}##installer-test-v1.32|v1.32|installer-${CLOUD_BRANCH}|${INSTALLER_RESULT_1_32}"
+              TEST_RESULT="${TEST_RESULT}##installer-test-v1.33|v1.33|installer-${CLOUD_BRANCH}|${INSTALLER_RESULT_1_32}"
           fi
           
           

--- a/.github/workflows/kbcli-test-k8s.yml
+++ b/.github/workflows/kbcli-test-k8s.yml
@@ -22,9 +22,9 @@ on:
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         required: false
@@ -71,7 +71,7 @@ on:
         description: 'k8s cluster version'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         type: string

--- a/.github/workflows/kubeblocks-e2e-test.yml
+++ b/.github/workflows/kubeblocks-e2e-test.yml
@@ -19,10 +19,10 @@ on:
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
-        default: '1.32'
+        default: '1.33'
       REGION:
         description: 'k8s region name'
         type: string

--- a/.github/workflows/terraform-init.yml
+++ b/.github/workflows/terraform-init.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: 'eks'
       cluster-version:
-        description: 'k8s cluster version (e.g. 1.32)'
+        description: 'k8s cluster version (e.g. 1.33)'
         type: string
         required: false
         default: ''


### PR DESCRIPTION
```
╷
│ Error: creating Kubernetes Cluster (Subscription: "***"
│ Resource Group Name: "***"
│ Kubernetes Cluster Name: "***"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with response: ***
│   "code": "K8sVersionNotSupported",
│   "details": null,
│   "message": "Managed cluster *** is on version 1.32.11, which is only available for Long-Term Support (LTS). If you intend to onboard to LTS, please ensure the cluster is in Premium tier and LTS support plan (see https://aka.ms/aks/enable-lts). Otherwise, use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list",
│   "subcode": ""
│  ***
│ 
│   with azurerm_kubernetes_cluster.default,
│   on aks.tf line 20, in resource "azurerm_kubernetes_cluster" "default":
│   20: resource "azurerm_kubernetes_cluster" "default" ***
│ 
╵
```