### PR TITLE
fix: keep ginkgo message when job lookup fails

### DIFF
--- a/.github/utils/utils.sh
+++ b/.github/utils/utils.sh
@@ -1032,13 +1032,35 @@ set_ginkgo_runs_jobs() {
     done
 }
 
+set_ginkgo_runs_jobs_fallback() {
+    local fallback_url="https://github.com/$GITHUB_REPO/actions/runs/$RUN_ID"
+    local test_result="$TEST_RESULT"
+    local ginkgo_test=0
+
+    if [[ "$test_result" == *"SUCCESS!"*"--"* || "$test_result" == *"FAIL!"*"--"* ]]; then
+        test_result="$(echo "${test_result}" | sed 's/ /#/g')"
+        ginkgo_test=1
+    fi
+
+    for test_ret in `echo "$test_result" | sed 's/##/ /g'`; do
+        if [[ -z "$test_ret" ]]; then
+            continue
+        fi
+        if [[ $ginkgo_test -eq 1 ]]; then
+            test_ret="$(echo "${test_ret}" | sed 's/#/ /g')"
+        fi
+        TEST_RET=$TEST_RET"##$test_ret|$fallback_url"
+    done
+}
+
 get_ginkgo_test_result() {
+    local jobs_api_failed=false
     for i in {1..2}; do
         jobs_url="$GITHUB_API/repos/$GITHUB_REPO/actions/runs/$RUN_ID/jobs?per_page=200&page=$i"
         jobs_list=$( gh_curl -s $jobs_url )
         total_count=$( echo "$jobs_list" | jq '.total_count' )
         if [[ "$total_count" == "null" || $(is_number "$total_count") == "false" ]]; then
-            echo "total_count:${total_count}"
+            jobs_api_failed=true
             break
         fi
         for i in $(seq 0 $total_count); do
@@ -1050,6 +1072,10 @@ get_ginkgo_test_result() {
             set_ginkgo_runs_jobs "$jobs_name" "$jobs_url"
         done
     done
+    if [[ "$jobs_api_failed" == "true" || -z "$TEST_RET" ]]; then
+        TEST_RET=""
+        set_ginkgo_runs_jobs_fallback
+    fi
     echo "$TEST_RET"
 }
 


### PR DESCRIPTION
## 背景

Daily API regression run <https://github.com/apecloud/apecloud-cd/actions/runs/27382975410> 中，`openapi-test` 和 `adminapi-test` 都已经成功：

- `openapi-test`: 473 Passed / 0 Failed / 15 Skipped
- `adminapi-test`: 236 Passed / 0 Failed / 21 Skipped

但最后的 `send-message` job 失败，原因是 `.github/utils/utils.sh --type 40` 在查询 GitHub jobs 列表失败时输出 `total_count:null`，后续 `.github/utils/send_mesage.py` 按 ginkgo result 格式解析该字符串，触发 `IndexError: list index out of range`。

## 改动

- `get_ginkgo_test_result` 查询 jobs API 失败或没有匹配到 job 时，不再输出 `total_count:null`。
- 增加 fallback：保留原始 ginkgo 测试结果，并给每条结果补当前 run 的总链接。
- 正常查询成功时仍保持原行为，给每条测试结果补具体 job 链接。

## 验证

- `bash -n .github/utils/utils.sh .github/utils/send_mesage.py` 通过
- 使用无效 token 复现 jobs API 异常，`utils.sh --type 40` 现在输出两条测试结果并补 run 总链接，不再输出 `total_count:null`
- 使用当前 GitHub token 验证正常路径，`utils.sh --type 40` 仍输出 openapi/adminapi 各自的 job 链接
- `git diff --check` 通过

## 边界

- 本 PR 只修复测试结果消息汇总脚本，不改 openapi/adminapi 测试逻辑。
- 今天 run 里的 API case 本身没有失败；合并后需要下一次 daily run 验证 `send-message` job 不再因为 job 链接查询兜底问题失败。